### PR TITLE
fixed previous messages not displaying bug

### DIFF
--- a/elements/chat-agent/lib/chat-input.js
+++ b/elements/chat-agent/lib/chat-input.js
@@ -31,16 +31,13 @@ class ChatInput extends DDD {
       this.darkMode = toJS(ChatStore.darkMode);
     })
     
-    autorun(() => {
+    autorun(() => { // ! these two need to run together to prevent bugs
       this.messageIndex = toJS(ChatStore.messageIndex);
+      this.previousMessagesIndex = toJS(this.messageIndex);
     })
     
     autorun(() => {
       this.userIndex = toJS(ChatStore.userIndex);
-    })
-    
-    autorun(() => {
-      this.previousMessagesIndex = toJS(this.messageIndex);
     })
     
     autorun(() => {


### PR DESCRIPTION
Showed my dad the stuff I worked on over the summer and found a bug caused by separating some autoruns lol. The bug basically wouldn't show previous messages in the textarea in the `chat-input` tag when the up arrow was pressed, but would show them when the down arrow was pressed. Fixed by ensuring `this.messageIndex` and `this.previousMessagesIndex` `autorun()` at the same time.