### PR TITLE
simple-tooltip RTL support made optional

### DIFF
--- a/elements/simple-tooltip/simple-tooltip.js
+++ b/elements/simple-tooltip/simple-tooltip.js
@@ -198,12 +198,15 @@ class SimpleTooltip extends LitElement {
         .hidden {
           position: absolute;
           left: -10000px;
-          inset-inline-start: -10000px;
-          inset-inline-end: initial;
           top: auto;
           width: 1px;
           height: 1px;
           overflow: hidden;
+        }
+
+        :host([dir="rtl"]) .hidden {
+          inset-inline-start: -10000px;
+          inset-inline-end: initial;
         }
       `,
     ];


### PR DESCRIPTION
I've moved the code I previously added to be dependent upon RTL attribute like is the case in other components. This is due to the fact that sometimes, with absolute positioning - some pages behave differently and therefore need this type of control.