### PR TITLE
Revert "simple-tooltip RTL support made optional"

### DIFF
--- a/elements/simple-tooltip/simple-tooltip.js
+++ b/elements/simple-tooltip/simple-tooltip.js
@@ -198,15 +198,12 @@ class SimpleTooltip extends LitElement {
         .hidden {
           position: absolute;
           left: -10000px;
+          inset-inline-start: -10000px;
+          inset-inline-end: initial;
           top: auto;
           width: 1px;
           height: 1px;
           overflow: hidden;
-        }
-
-        :host([dir="rtl"]) .hidden {
-          inset-inline-start: -10000px;
-          inset-inline-end: initial;
         }
       `,
     ];


### PR DESCRIPTION
Reverts haxtheweb/webcomponents#713

@btopro Really sorry but this change is not needed. Some change in our code led me to believe it was so please revert this. Turns out some forms of containment cause overflow problems and I thought it was the tooltip's fault and it's not. Sorry again.

One thing I would propose is do you want to add position="start" and "end" which will be automatically set to left or right based on the direction of the top level document. This feature does seem to be needed to provide a more seamless experience. Let me know what you think.