### PR TITLE
Added dddignore to all applicable webcomponents

### DIFF
--- a/elements/a11y-behaviors/.dddignore
+++ b/elements/a11y-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-carousel/.dddignore
+++ b/elements/a11y-carousel/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-collapse/.dddignore
+++ b/elements/a11y-collapse/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-compare-image/.dddignore
+++ b/elements/a11y-compare-image/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-details/.dddignore
+++ b/elements/a11y-details/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-figure/.dddignore
+++ b/elements/a11y-figure/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-gif-player/.dddignore
+++ b/elements/a11y-gif-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-media-player/.dddignore
+++ b/elements/a11y-media-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-menu-button/.dddignore
+++ b/elements/a11y-menu-button/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-tabs/.dddignore
+++ b/elements/a11y-tabs/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/a11y-utils/.dddignore
+++ b/elements/a11y-utils/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/absolute-position-behavior/.dddignore
+++ b/elements/absolute-position-behavior/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/accent-card/.dddignore
+++ b/elements/accent-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/aframe-player/.dddignore
+++ b/elements/aframe-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/air-horn/.dddignore
+++ b/elements/air-horn/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/anchor-behaviors/.dddignore
+++ b/elements/anchor-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/app-hax/.dddignore
+++ b/elements/app-hax/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/audio-player/.dddignore
+++ b/elements/audio-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/awesome-explosion/.dddignore
+++ b/elements/awesome-explosion/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/b-r/.dddignore
+++ b/elements/b-r/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/barcode-reader/.dddignore
+++ b/elements/barcode-reader/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/baseline-build-hax/.dddignore
+++ b/elements/baseline-build-hax/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/beaker-broker/.dddignore
+++ b/elements/beaker-broker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/bootstrap-theme/.dddignore
+++ b/elements/bootstrap-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/chartist-render/.dddignore
+++ b/elements/chartist-render/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/chat-agent/.dddignore
+++ b/elements/chat-agent/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/check-it-out/.dddignore
+++ b/elements/check-it-out/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/citation-element/.dddignore
+++ b/elements/citation-element/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/clean-one/.dddignore
+++ b/elements/clean-one/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/clean-portfolio-theme/.dddignore
+++ b/elements/clean-portfolio-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/clean-two/.dddignore
+++ b/elements/clean-two/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/cms-hax/.dddignore
+++ b/elements/cms-hax/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/code-editor/.dddignore
+++ b/elements/code-editor/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/code-sample/.dddignore
+++ b/elements/code-sample/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/collection-list/.dddignore
+++ b/elements/collection-list/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/count-up/.dddignore
+++ b/elements/count-up/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/course-design/.dddignore
+++ b/elements/course-design/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/course-model/.dddignore
+++ b/elements/course-model/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/csv-render/.dddignore
+++ b/elements/csv-render/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/d-d-d/.dddignore
+++ b/elements/d-d-d/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/d-d-docs/.dddignore
+++ b/elements/d-d-docs/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/data-viz/.dddignore
+++ b/elements/data-viz/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/date-card/.dddignore
+++ b/elements/date-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/discord-embed/.dddignore
+++ b/elements/discord-embed/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/disqus-embed/.dddignore
+++ b/elements/disqus-embed/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/dl-behavior/.dddignore
+++ b/elements/dl-behavior/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/documentation-player/.dddignore
+++ b/elements/documentation-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/dynamic-import-registry/.dddignore
+++ b/elements/dynamic-import-registry/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/editable-table/.dddignore
+++ b/elements/editable-table/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/elmsln-loading/.dddignore
+++ b/elements/elmsln-loading/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/enhanced-text/.dddignore
+++ b/elements/enhanced-text/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/event-badge/.dddignore
+++ b/elements/event-badge/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/evo-to-wc/.dddignore
+++ b/elements/evo-to-wc/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/example-hax-element/.dddignore
+++ b/elements/example-hax-element/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/example-haxcms-theme/.dddignore
+++ b/elements/example-haxcms-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/figure-label/.dddignore
+++ b/elements/figure-label/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/file-system-broker/.dddignore
+++ b/elements/file-system-broker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/fill-in-the-blanks/.dddignore
+++ b/elements/fill-in-the-blanks/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/flash-card/.dddignore
+++ b/elements/flash-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/fluid-type/.dddignore
+++ b/elements/fluid-type/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/full-width-image/.dddignore
+++ b/elements/full-width-image/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/fullscreen-behaviors/.dddignore
+++ b/elements/fullscreen-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/future-terminal-text/.dddignore
+++ b/elements/future-terminal-text/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/git-corner/.dddignore
+++ b/elements/git-corner/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/github-preview/.dddignore
+++ b/elements/github-preview/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/grade-book/.dddignore
+++ b/elements/grade-book/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/grid-plate/.dddignore
+++ b/elements/grid-plate/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/h-a-x/.dddignore
+++ b/elements/h-a-x/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/h5p-element/.dddignore
+++ b/elements/h5p-element/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hal-9000/.dddignore
+++ b/elements/hal-9000/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-body-behaviors/.dddignore
+++ b/elements/hax-body-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-body/.dddignore
+++ b/elements/hax-body/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-bookmarklet/.dddignore
+++ b/elements/hax-bookmarklet/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-cloud/.dddignore
+++ b/elements/hax-cloud/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-iconset/.dddignore
+++ b/elements/hax-iconset/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hax-logo/.dddignore
+++ b/elements/hax-logo/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/haxcms-elements/.dddignore
+++ b/elements/haxcms-elements/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/haxor-slevin/.dddignore
+++ b/elements/haxor-slevin/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hex-picker/.dddignore
+++ b/elements/hex-picker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/hexagon-loader/.dddignore
+++ b/elements/hexagon-loader/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/html-block/.dddignore
+++ b/elements/html-block/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/i18n-manager/.dddignore
+++ b/elements/i18n-manager/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/iframe-loader/.dddignore
+++ b/elements/iframe-loader/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/image-compare-slider/.dddignore
+++ b/elements/image-compare-slider/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/image-inspector/.dddignore
+++ b/elements/image-inspector/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/img-pan-zoom/.dddignore
+++ b/elements/img-pan-zoom/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/img-view-modal/.dddignore
+++ b/elements/img-view-modal/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/inline-audio/.dddignore
+++ b/elements/inline-audio/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/json-outline-schema/.dddignore
+++ b/elements/json-outline-schema/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/jwt-login/.dddignore
+++ b/elements/jwt-login/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/la-tex/.dddignore
+++ b/elements/la-tex/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lazy-image-helpers/.dddignore
+++ b/elements/lazy-image-helpers/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lazy-import-discover/.dddignore
+++ b/elements/lazy-import-discover/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/learn-two-theme/.dddignore
+++ b/elements/learn-two-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lesson-overview/.dddignore
+++ b/elements/lesson-overview/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/license-element/.dddignore
+++ b/elements/license-element/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lorem-data/.dddignore
+++ b/elements/lorem-data/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrn-gitgraph/.dddignore
+++ b/elements/lrn-gitgraph/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrn-math/.dddignore
+++ b/elements/lrn-math/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrn-table/.dddignore
+++ b/elements/lrn-table/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrn-vocab/.dddignore
+++ b/elements/lrn-vocab/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrndesign-chart/.dddignore
+++ b/elements/lrndesign-chart/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrndesign-imagemap/.dddignore
+++ b/elements/lrndesign-imagemap/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrndesign-timeline/.dddignore
+++ b/elements/lrndesign-timeline/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lrs-elements/.dddignore
+++ b/elements/lrs-elements/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/lunr-search/.dddignore
+++ b/elements/lunr-search/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/map-menu/.dddignore
+++ b/elements/map-menu/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/mark-the-words/.dddignore
+++ b/elements/mark-the-words/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/matching-question/.dddignore
+++ b/elements/matching-question/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/md-block/.dddignore
+++ b/elements/md-block/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/media-behaviors/.dddignore
+++ b/elements/media-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/media-image/.dddignore
+++ b/elements/media-image/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/media-quote/.dddignore
+++ b/elements/media-quote/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/meme-maker/.dddignore
+++ b/elements/meme-maker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/merit-badge/.dddignore
+++ b/elements/merit-badge/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/micro-frontend-registry/.dddignore
+++ b/elements/micro-frontend-registry/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/moar-sarcasm/.dddignore
+++ b/elements/moar-sarcasm/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/moment-element/.dddignore
+++ b/elements/moment-element/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/multiple-choice/.dddignore
+++ b/elements/multiple-choice/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/music-player/.dddignore
+++ b/elements/music-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/mutation-observer-import-mixin/.dddignore
+++ b/elements/mutation-observer-import-mixin/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/oer-schema/.dddignore
+++ b/elements/oer-schema/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/outline-designer/.dddignore
+++ b/elements/outline-designer/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/outline-player/.dddignore
+++ b/elements/outline-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/page-break/.dddignore
+++ b/elements/page-break/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/page-contents-menu/.dddignore
+++ b/elements/page-contents-menu/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/page-flag/.dddignore
+++ b/elements/page-flag/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/page-scroll-position/.dddignore
+++ b/elements/page-scroll-position/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/page-section/.dddignore
+++ b/elements/page-section/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/paper-input-flagged/.dddignore
+++ b/elements/paper-input-flagged/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/paper-stepper/.dddignore
+++ b/elements/paper-stepper/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/parallax-image/.dddignore
+++ b/elements/parallax-image/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/pdf-browser-viewer/.dddignore
+++ b/elements/pdf-browser-viewer/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/person-testimonial/.dddignore
+++ b/elements/person-testimonial/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/place-holder/.dddignore
+++ b/elements/place-holder/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/play-list/.dddignore
+++ b/elements/play-list/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/polaris-theme/.dddignore
+++ b/elements/polaris-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/portal-launcher/.dddignore
+++ b/elements/portal-launcher/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/post-card/.dddignore
+++ b/elements/post-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/pouch-db/.dddignore
+++ b/elements/pouch-db/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/product-card/.dddignore
+++ b/elements/product-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/product-glance/.dddignore
+++ b/elements/product-glance/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/product-offering/.dddignore
+++ b/elements/product-offering/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/progress-donut/.dddignore
+++ b/elements/progress-donut/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/promise-progress/.dddignore
+++ b/elements/promise-progress/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/q-r/.dddignore
+++ b/elements/q-r/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/radio-behaviors/.dddignore
+++ b/elements/radio-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/relative-heading/.dddignore
+++ b/elements/relative-heading/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/replace-tag/.dddignore
+++ b/elements/replace-tag/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/responsive-grid/.dddignore
+++ b/elements/responsive-grid/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/responsive-utility/.dddignore
+++ b/elements/responsive-utility/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/retro-card/.dddignore
+++ b/elements/retro-card/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/rich-text-editor/.dddignore
+++ b/elements/rich-text-editor/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/rpg-character/.dddignore
+++ b/elements/rpg-character/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/runkit-embed/.dddignore
+++ b/elements/runkit-embed/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/schema-behaviors/.dddignore
+++ b/elements/schema-behaviors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/scroll-button/.dddignore
+++ b/elements/scroll-button/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/secure-request/.dddignore
+++ b/elements/secure-request/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/self-check/.dddignore
+++ b/elements/self-check/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/shadow-style/.dddignore
+++ b/elements/shadow-style/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-autocomplete/.dddignore
+++ b/elements/simple-autocomplete/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-blog/.dddignore
+++ b/elements/simple-blog/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-colors-shared-styles/.dddignore
+++ b/elements/simple-colors-shared-styles/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-colors/.dddignore
+++ b/elements/simple-colors/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-cta/.dddignore
+++ b/elements/simple-cta/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-datetime/.dddignore
+++ b/elements/simple-datetime/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-emoji/.dddignore
+++ b/elements/simple-emoji/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-fields/.dddignore
+++ b/elements/simple-fields/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-filter/.dddignore
+++ b/elements/simple-filter/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-icon-picker/.dddignore
+++ b/elements/simple-icon-picker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-icon/.dddignore
+++ b/elements/simple-icon/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-img/.dddignore
+++ b/elements/simple-img/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-login/.dddignore
+++ b/elements/simple-login/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-modal/.dddignore
+++ b/elements/simple-modal/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-picker/.dddignore
+++ b/elements/simple-picker/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-popover/.dddignore
+++ b/elements/simple-popover/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-progress/.dddignore
+++ b/elements/simple-progress/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-range-input/.dddignore
+++ b/elements/simple-range-input/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-search/.dddignore
+++ b/elements/simple-search/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-toast/.dddignore
+++ b/elements/simple-toast/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-toolbar/.dddignore
+++ b/elements/simple-toolbar/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-tooltip/.dddignore
+++ b/elements/simple-tooltip/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/simple-wc/.dddignore
+++ b/elements/simple-wc/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/social-share-link/.dddignore
+++ b/elements/social-share-link/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/sorting-question/.dddignore
+++ b/elements/sorting-question/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/spotify-embed/.dddignore
+++ b/elements/spotify-embed/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/star-rating/.dddignore
+++ b/elements/star-rating/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/stop-note/.dddignore
+++ b/elements/stop-note/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/super-daemon/.dddignore
+++ b/elements/super-daemon/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/tagging-question/.dddignore
+++ b/elements/tagging-question/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/terrible-themes/.dddignore
+++ b/elements/terrible-themes/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/training-theme/.dddignore
+++ b/elements/training-theme/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/twitter-embed/.dddignore
+++ b/elements/twitter-embed/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/type-writer/.dddignore
+++ b/elements/type-writer/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/un-sdg/.dddignore
+++ b/elements/un-sdg/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/undo-manager/.dddignore
+++ b/elements/undo-manager/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/unity-webgl/.dddignore
+++ b/elements/unity-webgl/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/user-action/.dddignore
+++ b/elements/user-action/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/user-scaffold/.dddignore
+++ b/elements/user-scaffold/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/video-player/.dddignore
+++ b/elements/video-player/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/vocab-term/.dddignore
+++ b/elements/vocab-term/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/voice-recorder/.dddignore
+++ b/elements/voice-recorder/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/wc-autoload/.dddignore
+++ b/elements/wc-autoload/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/web-container/.dddignore
+++ b/elements/web-container/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/wikipedia-query/.dddignore
+++ b/elements/wikipedia-query/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/word-count/.dddignore
+++ b/elements/word-count/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js

--- a/elements/wysiwyg-hax/.dddignore
+++ b/elements/wysiwyg-hax/.dddignore
@@ -1,0 +1,39 @@
+# Directories
+# (Must start with with / or \, as seen below)
+/.github # Inline comments are supported
+/.vscode
+/.idea
+/locales
+\test
+/dist
+/build
+/public # ignored by program regardless of presence in .dddignore
+/node_modules # ignored by program regardless of presence in .dddignore
+
+# Files 
+# (Must include filename and extension, as seen below)
+LICENSE
+.dddignore
+.editorconfig
+.gitignore
+.gitkeep
+.nojekyll
+.npmignore
+.surgeignore
+rollup.config.js
+
+# File extension
+# (Must start with *, as seen below)
+*.html
+*.md
+*.yml
+*.json
+*.toml
+*.mjs
+*.cjs
+*.png
+*.ico
+*.svg
+*.jpg
+*.jpeg
+*.stories.js


### PR DESCRIPTION
Bash scripting is magical 🪄

Copied and pasted a modified .dddignore into all components. Modifications from boilerplate are additions of `.gitkeep` and `*.stories.js`, for older components. Also went through each folder and removed .dddignore from any  that seemed to not be a component.

If for some reason ever needed in the future, here is the bash script I used:
`find webcomponents/elements -maxdepth 1 -type d -exec cp .dddignore {} \; `