### PR TITLE
[app-hax] Fix dashboard api-keys/media save aliases to target PATCH write opIds (D59)

### DIFF
--- a/elements/app-hax/lib/v2/AppHaxBackendAPI.js
+++ b/elements/app-hax/lib/v2/AppHaxBackendAPI.js
@@ -92,16 +92,16 @@ const APP_HAX_SYSTEM_CALL_ALIASES = {
     method: "GET",
   },
   saveApiKeys: {
-    operationId: "saveApiKeysPost",
-    method: "POST",
+    operationId: "saveApiKeysPatch",
+    method: "PATCH",
   },
   getMediaSettings: {
     operationId: "getMediaSettings",
     method: "GET",
   },
   saveMediaSettings: {
-    operationId: "saveMediaSettingsPost",
-    method: "POST",
+    operationId: "saveMediaSettingsPatch",
+    method: "PATCH",
   },
   systemBlocksList: {
     operationId: "systemBlocksGet",


### PR DESCRIPTION
## Summary

Fixes the dashboard api-keys and media \"save\" aliases so they target the **PATCH (write)** opIds instead of the POST (read) opIds. Previously `saveApiKeys`/`saveMediaSettings` mapped to `saveApiKeysPost`/`saveMediaSettingsPost` (POST = read per D59), so dashboard saves never persisted — they hit the read alias and returned current state without writing.

## Change

`elements/app-hax/lib/v2/AppHaxBackendAPI.js` (2 aliases, 4 lines):

- `saveApiKeys` → `operationId: "saveApiKeysPatch"`, `method: "PATCH"`
- `saveMediaSettings` → `operationId: "saveMediaSettingsPatch"`, `method: "PATCH"`

The write opIds (`saveApiKeysPatch`/`saveMediaSettingsPatch`) declare `userTokenHeader` and enforce it; the frontend registry auto-attaches `userToken` for ops declaring `userTokenHeader`, so dashboard saves now hit the write handler and persist.

## Validation

- `node --check` clean on the touched file.
- End-to-end save-flow verification is hands-on after the ubiquity build (no automated dashboard-save e2e exists in the webcomponents repo).

## Related

Companion to the backend system-read userToken enforcement PRs (haxcms-nodejs #19, haxcms-php #615) — once those land, dashboard saves hit PATCH handlers that enforce `X-HAXCMS-User-Token`, which the registry attaches automatically.

Co-Authored-By: Oz <oz-agent@warp.dev>