### PR TITLE
[app-hax] Remove dead response.data.contents check in import flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+security_best_practices_report.md
 .DS_Store
 arth111-jeopardy
 lerna-debug.log

--- a/elements/app-hax/lib/v2/app-hax-use-case-filter.js
+++ b/elements/app-hax/lib/v2/app-hax-use-case-filter.js
@@ -2712,7 +2712,6 @@ export class AppHaxUseCaseFilter extends LitElement {
         response &&
         response.status == 200 &&
         response.data &&
-        response.data.contents != "" &&
         Array.isArray(response.data.items)
       ) {
         const items = response.data.items;


### PR DESCRIPTION
## Summary

Fixes a Bucket B finding from the system spec audit: `processImportTemplate` in `app-hax-use-case-filter.js` checked `response.data.contents != ""` as a success guard, but no import handler returns a top-level `contents` field.

## The bug

`response.data.contents` is `undefined` for all import handlers (importDocx, importPdf, importPptx, importXlsx, htmlToSite, gitbookToSite, haxcmsToSite, notionToSite, pressbooksToSite, wordpressToSite, drupalBookToSite, ploneToSite). The check `undefined != ""` is `true` (loose inequality), so it was a dead no-op. But it was fragile — if any handler ever returned `contents: ""`, all imports would silently fail with "Import did not return a valid structure".

## The fix

Removed the `response.data.contents != "" &&` condition. The `Array.isArray(response.data.items)` check is the real guard and matches what every import handler actually returns.

## Coupled PRs

- **haxcms-nodejs**: `fix/system-spec-underdocumented` (#23) — system spec doc fixes from the same audit
- **haxcms-php**: `fix/system-spec-sync-php` — byte-identical spec sync

These two system PRs should be reviewed together with this one.

Co-Authored-By: Oz <oz-agent@warp.dev>