### PR TITLE
[security] Remediate High/Medium findings from security best-practices review (H-1..H-3, M-1..M-5)

### DIFF
--- a/elements/disqus-embed/disqus-embed.js
+++ b/elements/disqus-embed/disqus-embed.js
@@ -170,6 +170,11 @@ class DisqusBroker extends LitElement {
   }
 
   createEmbedScript(target, name) {
+    // security: validate shortName before interpolating into the Disqus host (prevents host injection)
+    if (!name || !/^[a-zA-Z0-9_-]+$/.test(name)) {
+      console.warn("disqus-embed: invalid shortName, refusing to load embed script");
+      return;
+    }
     this.renderTarget = target;
     this.innerHTML = "";
     if (!this._embed) {
@@ -177,6 +182,7 @@ class DisqusBroker extends LitElement {
       this._embed.setAttribute("data-timestamp", +new Date());
       this._embed.type = "text/javascript";
       this._embed.async = true;
+      // security note: Disqus embed.js has no published SRI hash; shortName validation is the primary control here.
       this._embed.src = `https://${name}.disqus.com/embed.js`;
       this.insertAdjacentElement("afterend", this._embed);
     }

--- a/elements/github-preview/lib/wc-markdown.js
+++ b/elements/github-preview/lib/wc-markdown.js
@@ -1,4 +1,5 @@
 import { markdownToHTML } from "@haxtheweb/utils/lib/markdown.js";
+import { sanitizeHTMLString } from "@haxtheweb/utils/utils.js";
 
 export class WCMarkdown extends HTMLElement {
   static get observedAttributes() {
@@ -69,17 +70,13 @@ export class WCMarkdown extends HTMLElement {
     let contents = this.__value;
     contents = WCMarkdown.prepare(contents);
     contents = await WCMarkdown.toHtml(contents);
-    this.innerHTML = contents;
+    // security: sanitize markdown HTML before innerHTML assignment (prevents stored XSS)
+    this.innerHTML = sanitizeHTMLString(contents);
   }
 
+  // security: do not un-escape HTML entities for untrusted remote markdown (re-activates escaped markup)
   static prepare(markdown) {
-    return markdown
-      .split("\n")
-      .map((line) => {
-        line = line.replace("&lt;", "<");
-        return line.replace("&gt;", ">");
-      })
-      .join("\n");
+    return markdown;
   }
 
   static async toHtml(markdown) {

--- a/elements/h5p-element/lib/h5p-resizer.js
+++ b/elements/h5p-element/lib/h5p-resizer.js
@@ -86,9 +86,8 @@
   
     // Listen for messages from iframes
     globalThis.addEventListener('message', function receiveMessage(event) {
-      // if (event.data.context !== 'h5p') {
-      //   return; // Only handle h5p requests.
-      // }
+      // security: ignore non-object message data (JS-MSG-001)
+      if (!event.data || typeof event.data !== 'object') { return; }
   
       // Find out who sent the message
       var iframe, iframes = globalThis.document.getElementsByTagName('iframe');
@@ -104,7 +103,8 @@
       }
   
       // Find action handler handler
-      if (actionHandlers[event.data.action]) {
+      // security: standard h5p resize messages require context === 'h5p' (JS-MSG-001)
+      if (event.data.context === 'h5p' && actionHandlers[event.data.action]) {
         actionHandlers[event.data.action](iframe, event.data, function respond(action, data) {
           if (data === undefined) {
             data = {};
@@ -142,7 +142,8 @@
     };
     for (var i = 0; i < iframes.length; i++) {
       if (iframes[i].src.indexOf('h5p') !== -1) {
-        iframes[i].contentWindow.postMessage(ready, '*');
+        // security: target the iframe's own origin instead of '*' (JS-MSG-001)
+        try { iframes[i].contentWindow.postMessage(ready, new URL(iframes[i].src).origin); } catch (e) {}
       }
     }
   

--- a/elements/haxcms-elements/lib/core/utils/LTIResizingMixin.js
+++ b/elements/haxcms-elements/lib/core/utils/LTIResizingMixin.js
@@ -4,6 +4,23 @@ import "@haxtheweb/es-global-bridge/es-global-bridge.js";
 import { store } from "@haxtheweb/haxcms-elements/lib/core/haxcms-site-store.js";
 import { autorun } from "mobx";
 
+// security: resolve the known LMS origin to use as postMessage targetOrigin instead of '*' (JS-MSG-001)
+function getLtiTargetOrigin() {
+  try {
+    const cmsStore =
+      globalThis.HAXCMS && globalThis.HAXCMS.instance &&
+      globalThis.HAXCMS.instance.store;
+    const settings = cmsStore && cmsStore.appSettings;
+    if (settings && settings.ltiOrigin) {
+      return settings.ltiOrigin;
+    }
+    if (globalThis.document && globalThis.document.referrer) {
+      return new URL(globalThis.document.referrer).origin;
+    }
+  } catch (e) {}
+  return globalThis.location.origin;
+}
+
 export const LTIResizingMixin = function (SuperClass) {
   return class extends SuperClass {
     constructor() {
@@ -20,7 +37,7 @@ export const LTIResizingMixin = function (SuperClass) {
       autorun(() => {
         // on content change, meaning it loaded, fire a resize statement
         if (store.activeItemContent || store.appReady) {
-          parent.postMessage('{"subject":"lti.scrollToTop"}', "*");
+          parent.postMessage('{"subject":"lti.scrollToTop"}', getLtiTargetOrigin());
           setTimeout(() => {
             let height = globalThis.document.body.scrollHeight;
             // scroll target is the content container
@@ -33,9 +50,9 @@ export const LTIResizingMixin = function (SuperClass) {
             // Resize the window via canvas API so we don't have 2 scroll bars.
             parent.postMessage(
               '{"subject":"lti.frameResize", "height":' + height + " }",
-              "*",
+              getLtiTargetOrigin(),
             );
-            parent.postMessage('{"subject":"lti.scrollToTop"}', "*");
+            parent.postMessage('{"subject":"lti.scrollToTop"}', getLtiTargetOrigin());
           }, 100);
           // give content a chance to self resize if loading nested materials
           setTimeout(() => {
@@ -50,9 +67,9 @@ export const LTIResizingMixin = function (SuperClass) {
             // Resize the window via canvas API so we don't have 2 scroll bars.
             parent.postMessage(
               '{"subject":"lti.frameResize", "height":' + height + " }",
-              "*",
+              getLtiTargetOrigin(),
             );
-            parent.postMessage('{"subject":"lti.scrollToTop"}', "*");
+            parent.postMessage('{"subject":"lti.scrollToTop"}', getLtiTargetOrigin());
           }, 1000);
         }
       });

--- a/elements/haxcms-elements/lib/core/utils/LTIResizingMixin.js
+++ b/elements/haxcms-elements/lib/core/utils/LTIResizingMixin.js
@@ -12,13 +12,16 @@ function getLtiTargetOrigin() {
       globalThis.HAXCMS.instance.store;
     const settings = cmsStore && cmsStore.appSettings;
     if (settings && settings.ltiOrigin) {
-      return settings.ltiOrigin;
+      if (settings.ltiOrigin === '*') {
+        return '*';
+      }
+      return new URL(settings.ltiOrigin).origin;
     }
     if (globalThis.document && globalThis.document.referrer) {
       return new URL(globalThis.document.referrer).origin;
     }
   } catch (e) {}
-  return globalThis.location.origin;
+  return globalThis.location && globalThis.location.origin ? globalThis.location.origin : '*';
 }
 
 export const LTIResizingMixin = function (SuperClass) {

--- a/elements/haxcms-elements/lib/ui-components/site/site-remote-content.js
+++ b/elements/haxcms-elements/lib/ui-components/site/site-remote-content.js
@@ -9,6 +9,7 @@ import {
   wipeSlot,
   lightChildrenToShadowRootSelector,
   unwrap,
+  sanitizeHTMLForImport,
 } from "@haxtheweb/utils/utils.js";
 import { enableServices } from "@haxtheweb/micro-frontend-registry/lib/microServices.js";
 import { MicroFrontendRegistry } from "@haxtheweb/micro-frontend-registry/micro-frontend-registry.js";
@@ -228,19 +229,10 @@ class SiteRemoteContent extends HAXCMSI18NMixin(
       const cid = this.shadowRoot.querySelector("#content");
       // remove past stuff
       wipeSlot(cid);
-      // build fake div and encap the content from endpoint
-      let div = globalThis.document.createElement("div");
-      // encap script just to be paranoid
-      let html = response.data.content.replace(
-        /<script[\s\S]*?>/gi,
-        "&lt;script&gt;",
-      );
-      html = html.replace(/<\/script>/gi, "&lt;/script&gt;");
-      div.innerHTML = html;
-      // append as child of this element
-      this.appendChild(div);
-      // kill the div, the children spill into this tag
-      unwrap(div);
+      // security: sanitize remote page HTML via the shared import sanitizer (prevents stored XSS via onerror/onload)
+      const frag = sanitizeHTMLForImport(response.data.content);
+      // append sanitized fragment as child of this element
+      this.appendChild(frag);
       // update title and loading status
       this._remoteTitle = response.data.title;
       this.loading = false;

--- a/elements/jwt-login/jwt-login.js
+++ b/elements/jwt-login/jwt-login.js
@@ -294,7 +294,8 @@ class JwtLogin extends LitElement {
         this.__logoutInFlight = false;
         if (meta.redirect && this.redirectUrl) {
           setTimeout(() => {
-            globalThis.location.href = this.redirectUrl;
+            // security: validate scheme before navigation (JS-URL-001)
+            globalThis.location.href = this.safeRedirect(this.redirectUrl);
           }, 100);
         }
         break;
@@ -319,7 +320,8 @@ class JwtLogin extends LitElement {
     var redirect = meta.redirect;
     if (ctx === "logout" && redirect && this.redirectUrl) {
       setTimeout(() => {
-        globalThis.location.href = this.redirectUrl;
+        // security: validate scheme before navigation (JS-URL-001)
+        globalThis.location.href = this.safeRedirect(this.redirectUrl);
       }, 100);
       return;
     }
@@ -430,7 +432,8 @@ class JwtLogin extends LitElement {
       this.logoutUrl !== "undefined"
     ) {
       if (this.isDifferentDomain(this.logoutUrl)) {
-        globalThis.location.href = this.logoutUrl;
+        // security: validate scheme before navigation (JS-URL-001)
+        globalThis.location.href = this.safeRedirect(this.logoutUrl);
       } else {
         this.generateRequest(this.logoutUrl, {}, {
           context: "logout",
@@ -439,7 +442,8 @@ class JwtLogin extends LitElement {
       }
     } else if (redirect && this.redirectUrl) {
       setTimeout(() => {
-        globalThis.location.href = this.redirectUrl;
+        // security: validate scheme before navigation (JS-URL-001)
+        globalThis.location.href = this.safeRedirect(this.redirectUrl);
       }, 100);
     }
   }
@@ -452,6 +456,19 @@ class JwtLogin extends LitElement {
     } catch (error) {
       console.error("Invalid URL provided:", error);
       return false;
+    }
+  }
+
+  // security: only allow http(s) navigation; blocks javascript:/data: schemes that would execute on location.href assignment (JS-URL-001)
+  safeRedirect(raw) {
+    try {
+      const u = new URL(raw, globalThis.location.href);
+      if (u.protocol !== "https:" && u.protocol !== "http:") {
+        return "/";
+      }
+      return u.href;
+    } catch (e) {
+      return "/";
     }
   }
 

--- a/elements/linkedin-embed/lib/linkedin-embed.js
+++ b/elements/linkedin-embed/lib/linkedin-embed.js
@@ -337,11 +337,9 @@ class LinkedinEmbed extends DDD {
       }
     });
     badgeHost.appendChild(iframe);
-    if (iframe.contentWindow && iframe.contentWindow.document) {
-      iframe.contentWindow.document.open();
-      iframe.contentWindow.document.write(`<!doctype html><html><head><style>html,body{margin:0;padding:0;overflow:hidden;background:transparent;line-height:0;}</style></head><body>${badgeHtml}</body></html>`);
-      iframe.contentWindow.document.close();
-    }
+    // security: write badge via srcdoc instead of document.write (avoids JS-XSS-002 document.write sink)
+    iframe.srcdoc = `<!doctype html><html><head><style>html,body{margin:0;padding:0;overflow:hidden;background:transparent;line-height:0;}</style></head><body>${badgeHtml}</body></html>`;
+    // security follow-up: full iframe isolation (sandbox=allow-scripts) would break same-origin height measurement; deferred.
   }
 
   get _effectiveTheme() {

--- a/elements/md-block/md-block.js
+++ b/elements/md-block/md-block.js
@@ -6,6 +6,7 @@ import { LitElement, html, css } from "lit";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { DDD } from "@haxtheweb/d-d-d/d-d-d.js";
 import { marked } from "marked";
+import { sanitizeHTMLString } from "@haxtheweb/utils/utils.js";
 
 /**
  * `md-block`
@@ -135,13 +136,19 @@ class MdBlock extends DDD {
           const response = await fetch(this.source);
           if (response.ok) {
             const text = await response.text();
-            this._parsedMarkdown = await marked.parse(text);
+            // security: sanitize remote markdown HTML before unsafeHTML (prevents stored XSS)
+            this._parsedMarkdown = sanitizeHTMLString(
+              await marked.parse(text),
+            );
           }
         } catch (e) {
           // fail silently, leave empty
         }
       } else if (this.markdown) {
-        this._parsedMarkdown = await marked.parse(this.markdown);
+        // security: sanitize markdown HTML before unsafeHTML (prevents stored XSS)
+        this._parsedMarkdown = sanitizeHTMLString(
+          await marked.parse(this.markdown),
+        );
       } else {
         this._parsedMarkdown = "";
       }

--- a/elements/utils/utils.js
+++ b/elements/utils/utils.js
@@ -323,6 +323,33 @@ export function sanitizeHTMLForImport(
 }
 
 /**
+ * Sanitize an HTML string and return a safe serialized string for use with
+ * `unsafeHTML` / `innerHTML` sinks (mirrors sanitizeHTMLForImport's pipeline
+ * but returns a string instead of a DocumentFragment).
+ * @param {String} html - raw HTML to sanitize
+ * @param {Object} opts - same options as sanitizeHTMLForImport
+ * @returns {String} sanitized HTML string safe for string-based DOM sinks
+ */
+export function sanitizeHTMLString(
+  html,
+  { sanitizeTemplateContents = true, encapsulateScriptTags = true } = {},
+) {
+  const safeHTML = encapsulateScriptTags
+    ? encapScript(typeof html === "string" ? html : "")
+    : typeof html === "string"
+      ? html
+      : "";
+  const template = globalThis.document.createElement("template");
+  template.innerHTML = safeHTML;
+  sanitizeNodeTree(template.content, {
+    sanitizeTemplateContents: sanitizeTemplateContents,
+  });
+  // security: return serialized safe HTML for unsafeHTML/innerHTML sinks
+  // (prevents stored XSS via onerror/onload event handlers and javascript: URLs)
+  return template.innerHTML;
+}
+
+/**
  * Convert a base64 encoded string to type Blob
  * @param {String} b64Data - base64 encoded string
  * @param {String} contentType - type to mark as the encoding of the blob


### PR DESCRIPTION
## Summary

Remediates the **High** and **Medium** findings from the security best-practices review of the `webcomponents` monorepo. The fixes are surgical and reuse the project's existing sanitization utilities (`sanitizeHTMLForImport`, `removeBadJSEventAttributes`, URL helpers) — no new runtime dependency is introduced (DOMPurify adoption is deferred to a follow-up; it would require a ubiquity build).

Full audit report: `security_best_practices_report.md` (committed in the orchestrator checkout).
Plan: [Security best-practices remediation — webcomponents monorepo](https://app.warp.dev/drive/notebook/WebttKRveEW9Ja9SO9EFeQ)

## Findings addressed

| ID | Severity | Rule | File | Change |
|---|---|---|---|---|
| H-1 | High | JS-XSS-001 | `haxcms-elements/.../site-remote-content.js` | Route `@haxcms/pageCache` remote HTML through `sanitizeHTMLForImport` instead of a `<script>`-only regex (prevents stored XSS via `onerror`/`onload`). |
| H-2 | High | JS-XSS-001 | `md-block/md-block.js` | Sanitize `marked.parse` output with new `sanitizeHTMLString()` before `unsafeHTML`. |
| H-3 | High | JS-XSS-001 | `github-preview/lib/wc-markdown.js` | Sanitize before `innerHTML`; stop un-escaping `&lt;`/`&gt;` in `prepare()` for untrusted remote markdown. |
| M-1 | Medium | JS-MSG-001 | `h5p-element/lib/h5p-resizer.js` | Guard message handler against non-object data; require `context === 'h5p'` before dispatch; target iframe's own origin (from `src`) instead of `*` for the ready broadcast. Legacy `entityIframe.resize` path preserved. |
| M-2 | Medium | JS-MSG-001 | `haxcms-elements/.../LTIResizingMixin.js` | Add `getLtiTargetOrigin()` (no optional chaining) and use it as `targetOrigin` for all 5 `parent.postMessage` calls instead of `*`. |
| M-3 | Medium | JS-URL-001 | `jwt-login/jwt-login.js` | Add `safeRedirect()` that only allows `http:`/`https:` schemes; wrap all 4 `location.href` navigation sites. Preserves external IdP logout. |
| M-4 | Medium | JS-XSS-001 | `utils/utils.js` | Add `sanitizeHTMLString()` — a string-returning variant of `sanitizeHTMLForImport` for `unsafeHTML`/`innerHTML` sinks. Foundation for H-2/H-3. |
| M-5 | Medium | JS-SUPPLY-001, JS-XSS-002 | `disqus-embed/disqus-embed.js`, `linkedin-embed/lib/linkedin-embed.js` | Disqus: validate `shortName` against `^[a-zA-Z0-9_-]+$` before host interpolation (prevents host injection). LinkedIn: replace `document.write` of badge HTML with `iframe.srcdoc`. |

## Files changed (9, +104/−42)

- `elements/utils/utils.js`
- `elements/haxcms-elements/lib/ui-components/site/site-remote-content.js`
- `elements/md-block/md-block.js`
- `elements/github-preview/lib/wc-markdown.js`
- `elements/h5p-element/lib/h5p-resizer.js`
- `elements/haxcms-elements/lib/core/utils/LTIResizingMixin.js`
- `elements/jwt-login/jwt-login.js`
- `elements/disqus-embed/disqus-embed.js`
- `elements/linkedin-embed/lib/linkedin-embed.js`

## Validation

- `node --check` — **PASS** on all 9 files.
- No optional chaining (`?.`) introduced (project rule).
- Uses `globalThis`, not `window` (project rule).
- No `build/`, `dist/`, `node_modules/`, or `custom-elements.json` touched; no top-level build, ubiquity, or test commands run.
- `hax audit` could not be run cleanly due to a **pre-existing** broken symlink (`elements/simple-icon/lib/svgs/elmsln-custom` → `/var/www/elmsln/...`); it crashes the audit tool's `.dddignore` scan before reaching any element. None of these edits change CSS/DDD tokens, so DDD compliance is unaffected. Fixing the symlink/audit-tool is out of scope here (follow-up).

## Behavioral notes & follow-ups for review

- **M-2 LTI origin fallback (please review):** `getLtiTargetOrigin()` resolves `appSettings.ltiOrigin` → `document.referrer` origin → `location.origin` (last resort). In a real LTI embed, `location.origin` is the HAXcms site's own origin, **not** the LMS parent — so if `ltiOrigin` is unset and the referrer is unavailable (Referrer-Policy: no-referrer), LTI resize/scroll messages may silently not deliver. Recommendation: populate `appSettings.ltiOrigin` for LTI deployments, or consider making the last-resort fallback `*` (original behavior) if LTI resizing is critical. Flagged for your decision.
- **M-5b LinkedIn iframe sandbox deferred:** `iframe.sandbox = "allow-scripts"` was intentionally **not** set because the existing load handler reads `iframe.contentWindow.document.body.scrollHeight` for auto-sizing, which requires same-origin access. `srcdoc` alone removes the `document.write` sink; full sandbox isolation (with a `postMessage`-based height report) is a separate follow-up.
- **H-1 `unwrap` import:** `unwrap` is now unused in `site-remote-content.js` (left in the import to keep the diff minimal). Safe to remove later; a strict `no-unused-vars` lint may flag it.
- **M-4 sanitizer is still blocklist-based.** Adopting a true allowlist sanitizer (DOMPurify) is a larger, separate effort (adds a runtime dep requiring a ubiquity build).
- **Out of scope (Low findings):** L-1 CSP/SRI policy (needs backend/edge), L-2 vendored lib hygiene, L-3 `globalThis.X` DOM-clobbering, L-4 storage validate-on-read.

## How this was produced

Four local child agents worked in parallel in separate git worktrees (one per theme), then their commits were cherry-picked onto `origin/master` to form this branch. No commit/PR was made without explicit user approval.

Co-Authored-By: Oz <oz-agent@warp.dev>
