### PR TITLE
[app-hax] Surface 403 errors accurately and stop the refresh/logout loop

### DIFF
--- a/elements/app-hax/lib/v2/AppHaxBackendAPI.js
+++ b/elements/app-hax/lib/v2/AppHaxBackendAPI.js
@@ -341,6 +341,7 @@ export class AppHaxBackendAPI extends LitElement {
     return 200;
   }
   _handleFailedRequestStatus(
+    response = null,
     responseStatus = 0,
     retryKey = "",
     call = "",
@@ -385,6 +386,32 @@ export class AppHaxBackendAPI extends LitElement {
       return true;
     }
     if (responseStatus === 403) {
+      // Distinguish a hard authorization denial (no refresh can fix it)
+      // from a refreshable expired-bearer 403. Hard denials must NOT
+      // trigger the refresh -> retry -> logout loop.
+      const HARD_DENIAL_MESSAGES = [
+        "Admin access required",
+        "Access denied",
+        "system admin route requires system dashboard access",
+        "X-HAXCMS-User-Token header is required for this endpoint",
+        "Invalid X-HAXCMS-User-Token header",
+      ];
+      const denialMessage =
+        response &&
+        typeof response === "object" &&
+        typeof response.message === "string"
+          ? response.message
+          : "";
+      if (
+        denialMessage &&
+        HARD_DENIAL_MESSAGES.indexOf(denialMessage) !== -1
+      ) {
+        // Hard denial: surface the error, leave the session intact.
+        this._clearRetryCount(retryKey);
+        return true;
+      }
+      // Refreshable 403 (expired bearer, or no hard-denial message):
+      // keep the existing refresh -> retry -> clear behavior.
       const retryCount = this._incrementRetryCount(retryKey);
       if (retryCount > this.__maxRefreshRetries) {
         this._clearRetryCount(retryKey);
@@ -448,6 +475,7 @@ export class AppHaxBackendAPI extends LitElement {
     const responseStatus = this._resolveResponseStatus(response);
     if (
       this._handleFailedRequestStatus(
+        response,
         responseStatus,
         retryKey,
         call,
@@ -456,7 +484,9 @@ export class AppHaxBackendAPI extends LitElement {
         callback,
       )
     ) {
-      return {};
+      // Return the real response (status + message) so callers can
+      // detect and surface the failure instead of seeing an empty object.
+      return response;
     }
     if (responseStatus > 0 && responseStatus < 400) {
       this._clearRetryCount(retryKey);

--- a/elements/app-hax/lib/v2/app-hax-site-bar.js
+++ b/elements/app-hax/lib/v2/app-hax-site-bar.js
@@ -428,7 +428,20 @@ export class AppHaxSiteBars extends SimpleColors {
         // Download is special - it opens a download link
         if (activeOp === "downloadSite") {
           const response = store.AppHaxAPI.lastResponse.downloadSite;
-          if (response && response.data && response.data.link) {
+          // Guard against the failure shape: a non-2xx status or missing
+          // data means the download did not succeed — do not open a link.
+          if (
+            response &&
+            typeof response === "object" &&
+            typeof response.status === "number" &&
+            response.status >= 400
+          ) {
+            console.error(
+              "downloadSite failed with status:",
+              response.status,
+              response,
+            );
+          } else if (response && response.data && response.data.link) {
             const link = response.data.link;
             const name = response.data.name || "";
             // Use an anchor element so this is treated as a real navigation
@@ -462,13 +475,33 @@ export class AppHaxSiteBars extends SimpleColors {
     // Success sound for confirm is now handled centrally in
     // app-hax-confirmation-modal to avoid duplicate sounds.
 
-    store.toast(
-      `${site.metadata.site.name} ${op.replace("Site", "")} successful!`,
-      3000,
-      {
-        hat: "random",
-      },
-    );
+    // Report the operation outcome accurately. A non-2xx status means the
+    // operation failed — surface the backend message instead of a false
+    // "successful" toast.
+    const opResponse =
+      store.AppHaxAPI && store.AppHaxAPI.lastResponse
+        ? store.AppHaxAPI.lastResponse[op]
+        : null;
+    if (
+      opResponse &&
+      typeof opResponse === "object" &&
+      typeof opResponse.status === "number" &&
+      opResponse.status >= 400
+    ) {
+      const errMsg =
+        typeof opResponse.message === "string" && opResponse.message
+          ? opResponse.message
+          : `${site.metadata.site.name} ${op.replace("Site", "")} failed`;
+      store.toast(errMsg, 3000, { hat: "random" });
+    } else {
+      store.toast(
+        `${site.metadata.site.name} ${op.replace("Site", "")} successful!`,
+        3000,
+        {
+          hat: "random",
+        },
+      );
+    }
   }
 
   // CSS - specific to Lit

--- a/elements/app-hax/lib/v2/app-hax-site-creation-modal.js
+++ b/elements/app-hax/lib/v2/app-hax-site-creation-modal.js
@@ -918,8 +918,34 @@ export class AppHaxSiteCreationModal extends DDDSuper(LitElement) {
 
   async promiseProgressFinished(e) {
     if (e.detail.value) {
+      // Verify the create actually succeeded before showing the success
+      // view. A non-2xx status or missing data means creation failed —
+      // surface the backend message instead of confetti + "Go to Site".
+      const createResult = store.AppHaxAPI.lastResponse.createSite;
+      if (
+        !(
+          createResult &&
+          typeof createResult === "object" &&
+          typeof createResult.status === "number" &&
+          createResult.status >= 200 &&
+          createResult.status < 400 &&
+          createResult.data
+        )
+      ) {
+        this.currentStep = 1;
+        this.isCreating = false;
+        this.errorMessage =
+          createResult &&
+          typeof createResult === "object" &&
+          typeof createResult.message === "string" &&
+          createResult.message
+            ? createResult.message
+            : "Site creation failed. Please try again.";
+        return;
+      }
+
       // Site creation completed successfully!
-      const createResponse = store.AppHaxAPI.lastResponse.createSite.data;
+      const createResponse = createResult.data;
 
       // Set the real site URL from the API response
       if (createResponse && createResponse.slug) {
@@ -986,14 +1012,23 @@ export class AppHaxSiteCreationModal extends DDDSuper(LitElement) {
       return;
     }
 
-    let createResponse = null;
+    // Verify the create succeeded (status < 400 with data) before trusting
+    // the create response to match against the server list. On failure,
+    // skip the server-list refresh and return early.
+    const createResult =
+      api.lastResponse && api.lastResponse.createSite
+        ? api.lastResponse.createSite
+        : null;
     if (
-      api.lastResponse &&
-      api.lastResponse.createSite &&
-      api.lastResponse.createSite.data
+      !createResult ||
+      typeof createResult !== "object" ||
+      typeof createResult.status !== "number" ||
+      createResult.status >= 400 ||
+      !createResult.data
     ) {
-      createResponse = api.lastResponse.createSite.data;
+      return;
     }
+    const createResponse = createResult.data;
 
     // Give the backend a brief moment to complete async writes before a
     // cache-busted list refresh.

--- a/elements/app-hax/lib/v2/app-hax-site-details.js
+++ b/elements/app-hax/lib/v2/app-hax-site-details.js
@@ -271,7 +271,20 @@ export class AppHaxSiteDetails extends SimpleColors {
         // download is weird relative to the others
         if (activeOp === "downloadSite") {
           const response = store.AppHaxAPI.lastResponse.downloadSite;
-          if (response && response.data && response.data.link) {
+          // Guard against the failure shape: a non-2xx status or missing
+          // data means the download did not succeed — do not open a link.
+          if (
+            response &&
+            typeof response === "object" &&
+            typeof response.status === "number" &&
+            response.status >= 400
+          ) {
+            console.error(
+              "downloadSite failed with status:",
+              response.status,
+              response,
+            );
+          } else if (response && response.data && response.data.link) {
             const link = response.data.link;
             const name = response.data.name || "";
             // Use an anchor element so this is treated as a real navigation
@@ -301,13 +314,33 @@ export class AppHaxSiteDetails extends SimpleColors {
     );
     // Success sound for confirm is now handled centrally in
     // app-hax-confirmation-modal to avoid duplicate sounds.
-    store.toast(
-      `${site.metadata.site.name} ${op.replace("Site", "")} successful!`,
-      3000,
-      {
-        hat: "random",
-      },
-    );
+    // Report the operation outcome accurately. A non-2xx status means the
+    // operation failed — surface the backend message instead of a false
+    // "successful" toast.
+    const opResponse =
+      store.AppHaxAPI && store.AppHaxAPI.lastResponse
+        ? store.AppHaxAPI.lastResponse[op]
+        : null;
+    if (
+      opResponse &&
+      typeof opResponse === "object" &&
+      typeof opResponse.status === "number" &&
+      opResponse.status >= 400
+    ) {
+      const errMsg =
+        typeof opResponse.message === "string" && opResponse.message
+          ? opResponse.message
+          : `${site.metadata.site.name} ${op.replace("Site", "")} failed`;
+      store.toast(errMsg, 3000, { hat: "random" });
+    } else {
+      store.toast(
+        `${site.metadata.site.name} ${op.replace("Site", "")} successful!`,
+        3000,
+        {
+          hat: "random",
+        },
+      );
+    }
   }
 
   // HTML - specific to Lit

--- a/elements/micro-frontend-registry/micro-frontend-registry.js
+++ b/elements/micro-frontend-registry/micro-frontend-registry.js
@@ -297,9 +297,29 @@ export const MicroFrontendRegCapabilities = function (SuperClass) {
           if (rawResponse) {
             return response.text();
           }
-          return response.ok
-            ? response.json()
-            : { status: response.status, data: null };
+          if (response.ok) {
+            return response.json();
+          }
+          // On non-ok, attempt to parse the JSON body so callers can read
+          // the backend message (e.g. authorization denial reason). Keep
+          // `data: null` for backward compatibility with existing callers.
+          let body = null;
+          try {
+            body = await response.json();
+          } catch (e) {
+            body = null;
+          }
+          return {
+            status: response.status,
+            data: null,
+            message:
+              body &&
+              typeof body === "object" &&
+              typeof body.message === "string"
+                ? body.message
+                : "",
+            body: body,
+          };
         };
         let data = null;
         switch (method) {


### PR DESCRIPTION
## Problem
When a site lifecycle call (createSite/clone/archive/download/download-skeleton/save-as-template) returns 403, the app-hax frontend shows contradictory behavior:
- A **false success** screen with confetti and \"Go to Site\" (because `makeCall` always resolves and `promiseProgressFinished` never checks status).
- A **refresh → retry → 403 → logout** loop (`_handleFailedRequestStatus` treats every 403 as refreshable), ending in `_clearAuthSession(true)` → Azure logout (staging) or forced reload (X).

This masks the real backend error and logs the user out even when the session is valid.

## Fix
1. **`micro-frontend-registry.js`** `parseResponse`: on non-ok, parse the JSON body and return `{status, data: null, message, body}` so callers can read the backend denial reason (e.g. \"Admin access required\"). Additive — `data` stays `null` for backward compat; `rawResponse` branch and catch fallbacks unchanged.
2. **`AppHaxBackendAPI.js`**:
   - `_handleFailedRequestStatus`: new `response` param + a 403 hard-denial branch. Hard authorization denials (\"Admin access required\", \"Access denied\", \"system admin route requires system dashboard access\", \"X-HAXCMS-User-Token header is required for this endpoint\", \"Invalid X-HAXCMS-User-Token header\") return `true` (handled) WITHOUT dispatching `jwt-login-refresh-token`, incrementing the retry counter, or calling `_clearAuthSession` — the session stays intact. Refreshable 403s (\"Invalid bearer token\" or empty message) keep the existing refresh→retry→clear behavior. 401/404 branches unchanged.
   - `_makeSystemOperationCall`: passes `response` to the handler and returns the **real** response object (status + message) instead of `{}` on handled failure, so `lastResponse[call]` carries the failure detail. Try/catch `return {}` for the throw case preserved.
3. **`app-hax-site-creation-modal.js`** `promiseProgressFinished`: verifies `lastResponse.createSite` has `status >= 200 && status < 400 && data` before the success view; on failure returns to step 1 with the backend message (no confetti, no Go-to-Site, no server-list refresh). `_refreshSiteListingFromServer`: same status guard before trusting `createSite.data`.
4. **`app-hax-site-bar.js`** & **`app-hax-site-details.js`**: guard `downloadSite` response (no link on `status >= 400`) and report the backend message on failure instead of a false \"successful\" toast.

## Validation
- `node --check` passed on all 5 files.
- No optional chaining (`?.`) introduced. No `window` references (uses `globalThis` where needed).
- Re-read every changed method body to confirm brace balance, control flow, and that existing 401/404 branches + try/catch fallbacks are untouched.
- No automated tests added (per user preference); no build/ubiquity run.

## Manual verification (HAXiam staging dashboard, after the backend fix ships)
- Create / clone / archive / download-skeleton / save-as-template → succeed; success view + toast as before.
- Forced hard 403 (e.g. cross-tenant) → modal returns to naming step with the backend message; NO confetti; NO logout; session stays valid.
- Forced hard 403 on copy/archive/download → toast shows the backend message (or \"… failed\"); download does not open a link.
- Expired-bearer 403 (\"Invalid bearer token\" / empty) → still triggers the refresh→retry→logout path (not a hard denial).

Companion backend PR (root cause): https://github.com/haxtheweb/haxcms-php/pull/620

Co-Authored-By: Oz <oz-agent@warp.dev>